### PR TITLE
feat: expose level stats and policy on dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -214,6 +214,8 @@ export default function DashboardPage() {
               eligible={Boolean(levelMeta?.eligibleForNext)}
               reason={levelMeta?.reason ?? "승급 평가 정보를 불러왔습니다."}
               targetLevel={levelMeta?.targetLevel ?? level + 1}
+              stats={levelMeta?.stats ?? null}
+              policy={levelMeta?.policy ?? null}
             />
             <MetricCard title="작성한 문장 수" value={totalSentenceCount} tooltip="세션에서 학습자가 직접 작성하거나 복습한 문장 수" />
             <MetricCard title="학습한 어휘 수" value={studiedWordCount} tooltip="문장 외에 학습한 단어 또는 구절 개수" />

--- a/hooks/use-dashboard.ts
+++ b/hooks/use-dashboard.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useState } from "react"
 import type { AccessSummary } from "@/lib/payments/access-summary"
+import type { LevelStats, LevelUpPolicy } from "@/lib/logic/level-utils"
 
 export type PriorityConcept = {
   key: string
@@ -27,6 +28,8 @@ export type DashboardData = {
     reason: string
     targetLevel: number
     recentLevelEntry: { level: number; changed_at: string; source: string } | null
+    stats: LevelStats | null
+    policy: LevelUpPolicy | null
   }
   difficulty: {
     applied: boolean

--- a/lib/logic/level-utils.ts
+++ b/lib/logic/level-utils.ts
@@ -17,6 +17,13 @@ export type LevelStats = {
   stable_concept_ratio: number
   low_box_concept_count: number
 }
+export type LevelUpPolicy = {
+  level: number
+  min_total_attempts: number | null
+  min_correct_rate: number | null
+  min_box_level_ratio: number | null
+}
+// LevelUpPolicy: 레벨 승급 정책 임계값 정보를 담는다.
 
 export type LevelEvaluation = {
   eligible: boolean


### PR DESCRIPTION
## Summary
- level 평가 결과에서 통계와 승급 정책을 함께 조회해 levelMeta에 포함했습니다.
- 대시보드 훅과 타입을 갱신해 새 필드를 전달하고, 레벨 카드에서 "다음 목표" 정보를 노출하도록 했습니다.

## Testing
- pnpm lint *(실패 - next lint 설정 프롬프트 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68d211eb563c832383afdf9b55c9c799