### PR TITLE
Handle Supabase sign-out errors gracefully

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -81,9 +81,26 @@ export default function SettingsPage() {
   }
 
   const redirectHomeAfterSignOut = async () => {
-    await signOut()
-    router.push("/")
+    try {
+      const ok = await signOut()
+      if (ok) {
+        router.push("/")
+        return
+      }
+      toast({
+        title: "로그아웃에 실패했습니다.",
+        description: "네트워크 상태를 확인한 뒤 다시 시도해 주세요.",
+        variant: "destructive",
+      })
+    } catch (err: any) {
+      toast({
+        title: "로그아웃 처리 중 오류가 발생했습니다.",
+        description: err?.message ?? "잠시 후 다시 시도해 주세요.",
+        variant: "destructive",
+      })
+    }
   }
+  // redirectHomeAfterSignOut: 로그아웃 성공 시 홈으로 이동한다.
 
   const startPayment = async () => {
     if (!phone.trim()) {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -21,6 +21,7 @@ import { LogOut, Settings, Menu, Loader2 } from "lucide-react"
 import Link from "next/link"
 import { useSidebar } from "@/hooks/use-sidebar"
 import { useAuth } from "@/hooks/use-auth"
+import { useToast } from "@/hooks/use-toast"
 import { useRouter } from "next/navigation"
 import type { AccessSummary } from "@/lib/payments/access-summary"
 
@@ -73,6 +74,7 @@ export function Header() {
   const { toggle } = useSidebar()
   const { user, signOut, loading } = useAuth()
   const router = useRouter()
+  const { toast } = useToast()
   const [access, setAccess] = useState<AccessSummary | null>(null)
   const [badgeLoading, setBadgeLoading] = useState(false)
 
@@ -182,8 +184,24 @@ export function Header() {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={async () => {
-                    await signOut()
-                    router.push("/")
+                    try {
+                      const ok = await signOut()
+                      if (ok) {
+                        router.push("/")
+                        return
+                      }
+                      toast({
+                        title: "로그아웃에 실패했습니다.",
+                        description: "네트워크 상태를 확인한 뒤 다시 시도해 주세요.",
+                        variant: "destructive",
+                      })
+                    } catch (err: any) {
+                      toast({
+                        title: "로그아웃 처리 중 오류가 발생했습니다.",
+                        description: err?.message ?? "잠시 후 다시 시도해 주세요.",
+                        variant: "destructive",
+                      })
+                    }
                   }}
                 >
                   <LogOut className="mr-2 h-4 w-4" />

--- a/hooks/use-auth.tsx
+++ b/hooks/use-auth.tsx
@@ -20,7 +20,7 @@ type AuthContextType = {
   user: AppUser | null
   loading: boolean
   signIn: () => Promise<void>
-  signOut: () => Promise<void>
+  signOut: () => Promise<boolean>
   updateUser: (updates: Partial<AppUser>) => void
 }
 
@@ -124,15 +124,24 @@ export function AuthProvider({
     }
   }
 
-  const signOut = async () => {
+  const signOut = async (): Promise<boolean> => {
     setLoading(true)
     try {
-      await supabase.auth.signOut().catch(() => {})
-    } finally {
+      const { error } = await supabase.auth.signOut()
+      if (error) {
+        console.warn("[useAuth] 로그아웃에 실패했습니다.", error.message)
+        return false
+      }
       setUser(null)
+      return true
+    } catch (err: any) {
+      console.warn("[useAuth] 로그아웃 처리 중 예외가 발생했습니다.", err?.message ?? err)
+      throw err
+    } finally {
       setLoading(false)
     }
   }
+  // signOut: Supabase 로그아웃 요청을 보내고 성공 여부를 반환한다.
 
   const updateUser = (updates: Partial<AppUser>) => {
     if (!user) return


### PR DESCRIPTION
## Summary
- update the auth context to return a boolean result from `signOut` and log failures instead of clearing the user
- adjust header and settings pages to surface logout failures to the user and only navigate on success

## Testing
- pnpm lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d2362d2e0c8323b8e092cdbbd6bbde