### PR TITLE
feat: handle in-app browsers for oauth

### DIFF
--- a/hooks/use-auth.tsx
+++ b/hooks/use-auth.tsx
@@ -19,7 +19,7 @@ import { buildAppUser, type AppUser, type ProfileRow } from "@/lib/auth/app-user
 type AuthContextType = {
   user: AppUser | null
   loading: boolean
-  signIn: () => Promise<void>
+  signIn: () => Promise<string | null>
   signOut: () => Promise<boolean>
   updateUser: (updates: Partial<AppUser>) => void
 }
@@ -109,20 +109,22 @@ export function AuthProvider({
     }
   }, [hasInitialUser])
 
-  const signIn = async () => {
+  const signIn = async (): Promise<string | null> => {
     setLoading(true)
     try {
       const origin = typeof window !== "undefined" ? window.location.origin : ""
       const redirectTo = origin ? `${origin}/auth/callback?redirectedFrom=/dashboard` : undefined
-      const { error } = await supabase.auth.signInWithOAuth({
+      const { data, error } = await supabase.auth.signInWithOAuth({
         provider: "google",
-        options: { redirectTo },
+        options: { redirectTo, skipBrowserRedirect: true },
       })
       if (error) throw error
+      return data?.url ?? null
     } finally {
       setLoading(false)
     }
   }
+  // signIn: Google OAuth 로그인 URL을 발급하고 반환한다. (사용 시 수동 리디렉션 처리 필요)
 
   const signOut = async (): Promise<boolean> => {
     setLoading(true)

--- a/lib/device/is-inapp-browser.ts
+++ b/lib/device/is-inapp-browser.ts
@@ -1,0 +1,29 @@
+// 경로: lib/device/is-inapp-browser.ts
+// 역할: 주요 인앱 브라우저 환경을 감지하는 클라이언트 유틸리티.
+// 의존관계: window.navigator.userAgent
+// 포함 함수: isInAppBrowser()
+
+const IN_APP_PATTERNS: RegExp[] = [
+  /fbav/i,
+  /fban/i,
+  /fb_iab/i,
+  /fbss/i,
+  /instagram/i,
+  /kakaotalk/i,
+  /kakaostory/i,
+  /line\//i,
+  /naverapp/i,
+  /daumapps/i,
+  /;\s?wv/i,
+  /inappbrowser/i,
+  /kakaowebview/i,
+]
+
+export function isInAppBrowser(userAgent?: string): boolean {
+  const agent =
+    userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "")
+  if (!agent) return false
+
+  return IN_APP_PATTERNS.some((pattern) => pattern.test(agent))
+}
+// isInAppBrowser: 사용자 에이전트 문자열을 검사해 인앱 브라우저 여부를 판별한다. (사용 예: if (isInAppBrowser()) { ... })

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -13,7 +13,12 @@
     "title": "영어 학습 시작하기",
     "google_signin": "Google로 로그인",
     "signing_in": "로그인 중...",
-    "error": "로그인에 실패했습니다"
+    "error": "로그인에 실패했습니다",
+    "inapp_notice_title": "외부 브라우저에서 열어주세요",
+    "inapp_notice": "현재 앱 내장 브라우저에서는 로그인 완료가 어려울 수 있습니다. 우측 상단 ⋮ 메뉴에서 \"기본 브라우저로 열기\"를 선택하거나 Safari/Chrome 등 외부 브라우저에서 다시 열어주세요.",
+    "open_external": "외부 브라우저에서 열기",
+    "open_external_failed": "새 창을 열 수 없습니다. 브라우저 메뉴에서 \"기본 브라우저로 열기\"를 선택해주세요.",
+    "oauth_url_missing": "로그인 주소를 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
   },
   "onboarding": {
     "title": "학습 레벨 선택",


### PR DESCRIPTION
## Summary
- add a reusable in-app browser detector covering major SNS webviews
- update the auth sign-in helper to request OAuth URLs without automatic redirects
- guide in-app users on the sign-in page and allow retrying external browser opens with new locale strings

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d25338087083238f1938148251bfd4