### PR TITLE
Align onboarding status field naming

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -69,8 +69,7 @@ export async function POST(req: Request) {
       )
     }
 
-    // ⚠️ 컬럼명 주의: 프로젝트에서 실제 사용하는 컬럼이 onboarding_at 인지 onboarded_at 인지 확인하세요.
-    // 아래는 onboarded_at 기준으로 작성했습니다.
+    // ⚠️ 컬럼명 주의: 현재 프로젝트에서는 onboarded_at 컬럼을 사용합니다.
     // 4) DB 업데이트 (최초 1회만)
     const { data, error } = await supabase
       .from("users")

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,13 +45,13 @@ async function resolveInitialUser(): Promise<AppUser | null> {
 
     const { data, error } = await supabase
       .from("users")
-      .select("id, display_name, current_level, onboarding_at")
+      .select("id, display_name, current_level, onboarded_at")
       .eq("id", supaUser.id)
       .limit(1)
       .maybeSingle()
 
     const profile: ProfileRow | null = error || !data
-      ? { id: supaUser.id, display_name: null, current_level: null, onboarding_at: null }
+      ? { id: supaUser.id, display_name: null, current_level: null, onboarded_at: null }
       : (data as ProfileRow)
 
     return buildAppUser({ supaUser, profile })

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,13 +1,7 @@
-// app/onboarding/page.tsx
-// 목적: 레벨 선택 UI + 저장 버튼 → 서버 API 호출 → 성공/멱등이면 대시보드로 이동
-// 변경 요약:
-//  - (중요) 기존 로컬스토리지 의존과 Mock API 호출 제거
-//  - (중요) 신규 API /api/onboarding/complete 로 POST 호출
-//  - 완료/이미 완료(409) 모두 대시보드로 이동 → UX 안정
-//  - ProtectedRoute 는 인증만 담당(온보딩 여부는 서버/DB에서 판단)
-//
-// 참고: 기존 페이지는 localStorage 기반으로 온보딩 여부를 관리했습니다.
-//       이번 교체로 DB 단일 기준으로 일원화합니다.  :contentReference[oaicite:2]{index=2}
+// 경로: app/onboarding/page.tsx
+// 역할: 온보딩 레벨 선택 UI를 제공하고 완료 시 사용자 상태를 갱신한다.
+// 의존관계: @/components/auth/protected-route, @/hooks/use-auth, @/hooks/use-toast, @/lib/i18n
+// 포함 함수: OnboardingPage()
 
 "use client"
 
@@ -20,6 +14,7 @@ import { Label } from "@/components/ui/label"
 import { useTranslation } from "@/lib/i18n"
 import { useToast } from "@/hooks/use-toast"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { useAuth } from "@/hooks/use-auth"
 
 // 온보딩에서 노출하는 레벨 목록 (표시용은 L1~L9, 서버에선 정수 1~9로 변환)
 const levels = [
@@ -41,6 +36,7 @@ function toIntLevel(level: string): number | null {
   const n = Number(m[1])
   return n >= 1 && n <= 9 ? n : null
 }
+// toIntLevel: 레벨 문자열을 정수 레벨 값으로 변환한다.
 
 export default function OnboardingPage() {
   const [selectedLevel, setSelectedLevel] = useState<string>("")
@@ -48,6 +44,7 @@ export default function OnboardingPage() {
   const { t } = useTranslation()
   const { toast } = useToast()
   const router = useRouter()
+  const { updateUser } = useAuth()
 
   // 저장 처리: 서버 API 호출 후 라우팅
   const handleSave = async () => {
@@ -73,9 +70,14 @@ export default function OnboardingPage() {
       // 3) 결과 분기
       if (res.ok) {
         // 최초 성공(200)
+        const nowIso = new Date().toISOString()
         toast({
           title: t("onboarding.saved"),
           description: `${selectedLevel} ${t("onboarding.level_set_confirm") ?? "레벨로 설정되었습니다"}`,
+        })
+        updateUser({
+          current_level: lvInt,
+          onboarded_at: nowIso,
         })
         router.push("/dashboard")
         return
@@ -109,6 +111,7 @@ export default function OnboardingPage() {
       setIsSaving(false)
     }
   }
+  // handleSave: 온보딩 완료 요청을 보내고 사용자 상태를 갱신한다.
 
   return (
     <ProtectedRoute>

--- a/lib/auth/app-user.ts
+++ b/lib/auth/app-user.ts
@@ -14,7 +14,7 @@ export type AppUser = {
   role: AppUserRole
   image?: string
   current_level: number | null
-  onboarding_at: string | null
+  onboarded_at: string | null
   isFirstTime: boolean
 }
 
@@ -22,7 +22,7 @@ export type ProfileRow = {
   id: string
   display_name?: string | null
   current_level?: number | null
-  onboarding_at?: string | null
+  onboarded_at?: string | null
 }
 
 export function buildAppUser(params: {
@@ -48,7 +48,8 @@ export function buildAppUser(params: {
 
   const preferredName = (profile?.display_name && String(profile.display_name).trim()) || fullName
   const currentLevel = profile?.current_level ?? null
-  const onboardingAt = profile?.onboarding_at ?? null
+  const onboardedAt = profile?.onboarded_at ?? null
+  const isFirstTime = currentLevel === null || !onboardedAt
 
   return {
     id: supaUser.id,
@@ -57,8 +58,8 @@ export function buildAppUser(params: {
     role: "user",
     image: avatar,
     current_level: currentLevel,
-    onboarding_at: onboardingAt,
-    isFirstTime: currentLevel === null,
+    onboarded_at: onboardedAt,
+    isFirstTime,
   }
 }
 // buildAppUser: Supabase 사용자 정보를 앱 공용 사용자 모델로 매핑한다.


### PR DESCRIPTION
## Summary
- Supabase 프로필 조회와 AppUser/ProfileRow 타입의 온보딩 관련 필드를 `onboarded_at`으로 통일했습니다.
- 온보딩 완료 시 사용자 컨텍스트가 최신 레벨과 온보딩 완료 시각을 반영하도록 갱신했습니다.
- 온보딩 관련 API 및 레이아웃 초기화 로직에서도 새 필드명을 사용하도록 정리했습니다.

## Testing
- pnpm lint *(실패: Next.js ESLint 초기 설정 프롬프트 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68d3418728e48323ba17a0af3e216634