### PR TITLE
feat: surface bundle metrics in difficulty notices

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -235,10 +235,15 @@ export async function GET() {
       )
     }
 
+    const fallbackRecentRate = levelEval.stats?.recent_correct_rate ?? null
+    const fallbackLowBox = levelEval.stats?.low_box_concept_count ?? null
     let difficulty = {
       applied: false,
       reason: "최근 조정 기록 없음",
       applied_mix: null as Record<string, number> | null,
+      policy_level: null as number | null,
+      recent_correct_rate: fallbackRecentRate,
+      low_box_concept_count: fallbackLowBox,
     }
     if (levelEval.stats?.recent_session_id) {
       const { data: lastSession } = await supabase
@@ -248,10 +253,15 @@ export async function GET() {
         .maybeSingle()
       if (lastSession?.strategy_json) {
         const adj = extractAdjustmentFromStrategy(lastSession.strategy_json)
+        const rate = adj.recent_correct_rate ?? fallbackRecentRate
+        const lowBox = adj.low_box_concept_count ?? fallbackLowBox
         difficulty = {
           applied: adj.applied,
           reason: adj.reason || (adj.applied ? "난이도 조정 적용" : "조정 조건 미충족"),
           applied_mix: adj.applied_mix ?? null,
+          policy_level: adj.policy_level ?? null,
+          recent_correct_rate: rate,
+          low_box_concept_count: lowBox,
         }
       }
     }
@@ -308,6 +318,9 @@ export async function GET() {
         applied: false,
         reason: "데이터 없음",
         applied_mix: null,
+        policy_level: null,
+        recent_correct_rate: null,
+        low_box_concept_count: null,
       },
       access: EMPTY_ACCESS,
       free_sessions_left: EMPTY_ACCESS.free_sessions_left,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -188,6 +188,15 @@ export default function DashboardPage() {
   }
 
   const { level, delta30d, totalSentenceCount, studiedWordCount, priorityConcepts, gates, levelMeta, difficulty } = data
+  const difficultyNotice = difficulty
+    ? {
+        applied: difficulty.applied,
+        reason: difficulty.reason,
+        policy_level: difficulty.policy_level ?? null,
+        recent_correct_rate: difficulty.recent_correct_rate ?? null,
+        low_box_concept_count: difficulty.low_box_concept_count ?? null,
+      }
+    : undefined
   const monthLabel = `${ym.year}년 ${String(ym.month).padStart(2, "0")}월`
 
   const rankList: RankItem[] = priorityConcepts.map((item, idx) => ({
@@ -221,7 +230,7 @@ export default function DashboardPage() {
             <MetricCard title="학습한 어휘 수" value={studiedWordCount} tooltip="문장 외에 학습한 단어 또는 구절 개수" />
             <StartLearningCard
               disabledWeakSession={!gates.weakSessionEnabled}
-              difficultyNotice={difficulty ? { applied: difficulty.applied, reason: difficulty.reason } : undefined}
+              difficultyNotice={difficultyNotice}
               accessSummary={accessForCard}  // ✅ 보정된 access 전달 (관리자 신호 포함)
               totalSentenceCount={totalSentenceCount}
             />

--- a/components/dashboard/session-type-modal.tsx
+++ b/components/dashboard/session-type-modal.tsx
@@ -20,7 +20,13 @@ type SessionTypeModalProps = {
   onStartSession: (type: SessionType) => void
   totalSentenceCount: number
   preselectedType?: SessionType
-  difficultyNotice?: { applied: boolean; reason: string } | undefined
+  difficultyNotice?: {
+    applied: boolean
+    reason: string
+    policy_level?: number | null
+    recent_correct_rate?: number | null
+    low_box_concept_count?: number | null
+  }
 }
 
 const SESSION_TYPES: SessionType[] = ["new_only", "standard", "review_only", "weakness"]
@@ -62,6 +68,17 @@ export function SessionTypeModal({
               {difficultyNotice.applied
                 ? `이미 세션에 ${difficultyNotice.reason || "난이도 조정"}이 적용되었습니다.`
                 : `난이도 참고: ${difficultyNotice.reason || "추가 조정 없음"}`}
+              <span className="mt-1 block text-xs text-muted-foreground">
+                최근 정답률 {typeof difficultyNotice.recent_correct_rate === "number"
+                  ? `${Math.round(difficultyNotice.recent_correct_rate * 100)}%`
+                  : "-"}
+                , 낮은 박스 {typeof difficultyNotice.low_box_concept_count === "number"
+                  ? difficultyNotice.low_box_concept_count.toLocaleString()
+                  : "-"}
+                {typeof difficultyNotice.policy_level === "number"
+                  ? ` · 정책 레벨 L${difficultyNotice.policy_level}`
+                  : ""}
+              </span>
             </AlertDescription>
           </Alert>
         )}

--- a/components/dashboard/start-learning-card.tsx
+++ b/components/dashboard/start-learning-card.tsx
@@ -82,7 +82,13 @@ export function StartLearningCard({
 }: {
   disabledWeakSession?: boolean
   preferResumeLabel?: boolean
-  difficultyNotice?: { applied: boolean; reason: string }
+  difficultyNotice?: {
+    applied: boolean
+    reason: string
+    policy_level?: number | null
+    recent_correct_rate?: number | null
+    low_box_concept_count?: number | null
+  }
   accessSummary?: AccessSummary | null
   totalSentenceCount?: number
 }) {
@@ -239,6 +245,17 @@ export function StartLearningCard({
               {difficultyNotice.applied
                 ? `난이도 조정 적용: ${difficultyNotice.reason || "최근 학습 기록을 바탕으로 난이도가 조정되었어요."}`
                 : `난이도 안내: ${difficultyNotice.reason || "현재 기본 난이도로 진행됩니다."}`}
+              <span className="mt-1 block text-xs text-muted-foreground">
+                최근 정답률 {typeof difficultyNotice.recent_correct_rate === "number"
+                  ? `${Math.round(difficultyNotice.recent_correct_rate * 100)}%`
+                  : "-"}
+                , 낮은 박스 개념수 {typeof difficultyNotice.low_box_concept_count === "number"
+                  ? difficultyNotice.low_box_concept_count.toLocaleString()
+                  : "-"}
+                {typeof difficultyNotice.policy_level === "number"
+                  ? ` · 정책 레벨 L${difficultyNotice.policy_level}`
+                  : ""}
+              </span>
             </AlertDescription>
           </Alert>
         )}

--- a/components/learn/session-start-alert.tsx
+++ b/components/learn/session-start-alert.tsx
@@ -25,6 +25,17 @@ export function SessionStartAlert({ adjustment }: { adjustment: StrategyAdjustme
     )
   }
 
+  const recentRate =
+    typeof adjustment.recent_correct_rate === "number"
+      ? `${Math.round(adjustment.recent_correct_rate * 100)}%`
+      : null
+  const lowBox =
+    typeof adjustment.low_box_concept_count === "number"
+      ? adjustment.low_box_concept_count.toLocaleString()
+      : null
+  const policyLevel =
+    typeof adjustment.policy_level === "number" ? `L${adjustment.policy_level}` : null
+
   return (
     <Alert variant="destructive">
       <AlertTitle className="flex items-center gap-2">
@@ -32,6 +43,10 @@ export function SessionStartAlert({ adjustment }: { adjustment: StrategyAdjustme
       </AlertTitle>
       <AlertDescription>
         {adjustment.reason || "최근 성과를 기준으로 한 단계 낮은 난이도로 구성했어요."}
+        <span className="mt-1 block text-xs text-muted-foreground">
+          최근 정답률 {recentRate ?? "-"}, 낮은 박스 개념수 {lowBox ?? "-"}
+          {policyLevel ? ` · 정책 레벨 ${policyLevel}` : ""}
+        </span>
       </AlertDescription>
     </Alert>
   )

--- a/hooks/use-dashboard.ts
+++ b/hooks/use-dashboard.ts
@@ -35,6 +35,9 @@ export type DashboardData = {
     applied: boolean
     reason: string
     applied_mix: Record<string, number> | null
+    policy_level: number | null
+    recent_correct_rate: number | null
+    low_box_concept_count: number | null
   }
   access: AccessSummary
   free_sessions_left: number

--- a/lib/logic/level-utils.ts
+++ b/lib/logic/level-utils.ts
@@ -102,12 +102,33 @@ export function extractAdjustmentFromStrategy(strategy: any): StrategyAdjustment
         ])
       )
     : null
+  const rawPolicy = adj?.policy_level
+  const rawRecentRate = adj?.recent_correct_rate
+  const rawLowBox = adj?.low_box_concept_count
+  const policyLevel =
+    typeof rawPolicy === "number"
+      ? rawPolicy
+      : rawPolicy != null && !Number.isNaN(Number(rawPolicy))
+      ? Number(rawPolicy)
+      : null
+  const recentRate =
+    typeof rawRecentRate === "number"
+      ? rawRecentRate
+      : rawRecentRate != null && !Number.isNaN(Number(rawRecentRate))
+      ? Number(rawRecentRate)
+      : null
+  const lowBox =
+    typeof rawLowBox === "number"
+      ? rawLowBox
+      : rawLowBox != null && !Number.isNaN(Number(rawLowBox))
+      ? Number(rawLowBox)
+      : null
   return {
     applied: Boolean(adj?.applied),
     reason: typeof adj?.reason === "string" ? adj.reason : "",
-    policy_level: adj?.policy_level ?? null,
-    recent_correct_rate: adj?.recent_correct_rate ?? null,
-    low_box_concept_count: adj?.low_box_concept_count ?? null,
+    policy_level: policyLevel,
+    recent_correct_rate: recentRate,
+    low_box_concept_count: lowBox,
     applied_mix: normalizedMix,
   }
 }

--- a/supabase/migrations/20250205000000_session_bundle_metrics.sql
+++ b/supabase/migrations/20250205000000_session_bundle_metrics.sql
@@ -1,0 +1,252 @@
+-- 경로: supabase/migrations/20250205000000_session_bundle_metrics.sql
+-- 역할: 세션 번들 기반 학습 지표 뷰와 함수 로직 업데이트
+-- 의존관계: public.session_bundles, public.session_bundle_metrics, public.sessions, public.attempts, public.grades, public.user_concept_status, public.policy_level_adjustments, public.users
+-- 포함 함수: session_bundle_metrics 뷰 정의, get_user_level_stats(), get_difficulty_adjustment()
+
+begin;
+
+create or replace view public.session_bundle_metrics as
+select
+  sb.id as bundle_id,
+  sb.user_id,
+  sb.bundle_seq,
+  sb.started_at,
+  sb.ended_at,
+  (sb.summary_json->'metadata'->>'session_id')::uuid as session_id,
+  coalesce((sb.summary_json->'metrics'->>'total_items')::int, 0) as attempt_count,
+  coalesce((sb.summary_json->'metrics'->>'correct_items')::int, 0) as correct_count,
+  coalesce((sb.summary_json->'metrics'->>'duration_ms')::bigint, 0) as duration_ms,
+  case
+    when coalesce((sb.summary_json->'metrics'->>'total_items')::numeric, 0) > 0
+      then round(
+        coalesce((sb.summary_json->'metrics'->>'correct_items')::numeric, 0)
+        / nullif(coalesce((sb.summary_json->'metrics'->>'total_items')::numeric, 0), 0),
+        4
+      )
+    else 0
+  end as correct_rate
+from public.session_bundles sb;
+
+create or replace function get_user_level_stats(p_user_id uuid)
+returns table (
+  recent_session_id uuid,
+  recent_session_started_at timestamptz,
+  recent_session_ended_at timestamptz,
+  recent_attempts int,
+  recent_correct_attempts int,
+  recent_correct_rate numeric,
+  total_attempts bigint,
+  stable_concept_count bigint,
+  stable_concept_ratio numeric,
+  low_box_concept_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_total_concepts bigint;
+  v_recent_bundle_id uuid;
+  v_bundle_stats session_bundle_metrics%rowtype;
+  v_has_bundle_stats boolean := false;
+begin
+  recent_attempts := 0;
+  recent_correct_attempts := 0;
+  recent_correct_rate := 0;
+
+  select s.id,
+         s.started_at,
+         s.ended_at,
+         s.bundle_id
+  into recent_session_id,
+       recent_session_started_at,
+       recent_session_ended_at,
+       v_recent_bundle_id
+  from sessions s
+  where s.user_id = p_user_id
+    and s.status = 'completed'
+  order by coalesce(s.ended_at, s.started_at) desc
+  limit 1;
+
+  if recent_session_id is not null then
+    if v_recent_bundle_id is not null then
+      select sbm.*
+      into v_bundle_stats
+      from session_bundle_metrics sbm
+      where sbm.bundle_id = v_recent_bundle_id
+      limit 1;
+
+      v_has_bundle_stats := found;
+    end if;
+
+    if v_has_bundle_stats then
+      recent_attempts := coalesce(v_bundle_stats.attempt_count, 0);
+      recent_correct_attempts := coalesce(v_bundle_stats.correct_count, 0);
+      recent_correct_rate := coalesce(v_bundle_stats.correct_rate, 0);
+    else
+      select count(*)::int,
+             count(*) filter (where g.label in ('correct', 'variant'))::int
+      into recent_attempts,
+           recent_correct_attempts
+      from attempts a
+      left join grades g on g.attempt_id = a.id
+      where a.session_id = recent_session_id;
+
+      if recent_attempts > 0 then
+        recent_correct_rate := round((recent_correct_attempts::numeric / recent_attempts)::numeric, 4);
+      else
+        recent_correct_rate := 0;
+      end if;
+    end if;
+  end if;
+
+  select coalesce(sum(ucs.total_attempts), 0)
+  into total_attempts
+  from user_concept_status ucs
+  where ucs.user_id = p_user_id;
+
+  select coalesce(count(*), 0)
+  into stable_concept_count
+  from user_concept_status ucs
+  where ucs.user_id = p_user_id
+    and ucs.box_level >= 4;
+
+  select coalesce(count(*), 0)
+  into v_total_concepts
+  from user_concept_status ucs
+  where ucs.user_id = p_user_id;
+
+  stable_concept_ratio :=
+    case when v_total_concepts > 0
+         then round((stable_concept_count::numeric / v_total_concepts)::numeric, 4)
+         else 0 end;
+
+  select coalesce(count(*), 0)
+  into low_box_concept_count
+  from user_concept_status ucs
+  where ucs.user_id = p_user_id
+    and ucs.box_level <= 2;
+
+  return next;
+end;
+$$;
+-- get_user_level_stats: 번들 요약 기반 사용자 레벨 통계 반환
+
+create or replace function get_difficulty_adjustment(p_user_id uuid)
+returns table (
+  applied boolean,
+  reason text,
+  policy_level int,
+  recent_correct_rate numeric,
+  low_box_concept_count bigint,
+  adjusted_mix jsonb
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_level int;
+  v_condition jsonb;
+  v_threshold_rate numeric;
+  v_threshold_low int;
+  v_recent_bundle_rows int := 0;
+  v_attempt_summary record;
+begin
+  select current_level
+  into v_level
+  from users
+  where id = p_user_id;
+
+  if v_level is null then
+    applied := false;
+    reason := '사용자 레벨 정보 없음';
+    policy_level := null;
+    recent_correct_rate := 0;
+    low_box_concept_count := 0;
+    adjusted_mix := null;
+    return next;
+  end if;
+
+  policy_level := v_level;
+
+  with recent_bundle_stats as (
+    select sbm.attempt_count,
+           sbm.correct_count
+    from sessions s
+    join session_bundle_metrics sbm on sbm.bundle_id = s.bundle_id
+    where s.user_id = p_user_id
+      and s.status = 'completed'
+    order by coalesce(s.ended_at, s.started_at) desc
+    limit 3
+  )
+  select case
+           when coalesce(sum(attempt_count), 0) > 0 then round((sum(correct_count)::numeric / sum(attempt_count))::numeric, 4)
+           else null
+         end,
+         count(*)
+  into recent_correct_rate,
+       v_recent_bundle_rows
+  from recent_bundle_stats;
+
+  if recent_correct_rate is null then
+    with recent_sessions as (
+      select s.id
+      from sessions s
+      where s.user_id = p_user_id
+        and s.status = 'completed'
+      order by coalesce(s.ended_at, s.started_at) desc
+      limit 3
+    )
+    select count(*)::int as attempt_count,
+           count(*) filter (where g.label in ('correct', 'variant'))::int as correct_count
+    into v_attempt_summary
+    from attempts a
+    left join grades g on g.attempt_id = a.id
+    where a.session_id in (select id from recent_sessions);
+
+    if coalesce(v_attempt_summary.attempt_count, 0) > 0 then
+      recent_correct_rate := round((coalesce(v_attempt_summary.correct_count, 0)::numeric / v_attempt_summary.attempt_count)::numeric, 4);
+    else
+      recent_correct_rate := 0;
+    end if;
+  end if;
+
+  select coalesce(gs.low_box_concept_count, 0)
+  into low_box_concept_count
+  from get_user_level_stats(p_user_id) as gs;
+
+  select condition_json, adjusted_mix_json
+  into v_condition, adjusted_mix
+  from policy_level_adjustments
+  where level = v_level;
+
+  if v_condition is null or adjusted_mix is null then
+    applied := false;
+    reason := '조정 조건 미충족';
+    adjusted_mix := null;
+    return next;
+  end if;
+
+  v_threshold_rate := coalesce((v_condition->>'recent_correct_rate_below')::numeric, 0.6);
+  v_threshold_low := coalesce((v_condition->>'low_box_concepts_over')::int, 5);
+
+  if recent_correct_rate < v_threshold_rate
+     and low_box_concept_count >= v_threshold_low then
+    applied := true;
+    reason := format('최근 정답률 %.2f < 기준 %.2f, 낮은 박스 %s ≥ %s',
+                     recent_correct_rate, v_threshold_rate,
+                     low_box_concept_count, v_threshold_low);
+    adjusted_mix := normalize_level_mix(adjusted_mix);
+  else
+    applied := false;
+    reason := '조정 조건 미충족';
+    adjusted_mix := null;
+  end if;
+
+  return next;
+end;
+$$;
+-- get_difficulty_adjustment: 번들 지표 기반 난이도 조정 판단
+
+commit;


### PR DESCRIPTION
## Summary
- expose bundle-derived difficulty metrics from the dashboard API response
- coerce strategy adjustment metadata into numeric values before passing to the client
- surface recent correct rate and low-box counts in dashboard and session start notices

## Testing
- `pnpm lint` *(fails: command prompts for interactive ESLint config in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d34b31b624832387c5c62b226aafff