### PR TITLE
학습 지표 문구 개선 및 카드 단순화

### DIFF
--- a/components/dashboard/session-type-modal.tsx
+++ b/components/dashboard/session-type-modal.tsx
@@ -68,12 +68,13 @@ export function SessionTypeModal({
                 : " -"}
               입니다.
               <span className="mt-1 block text-xs text-muted-foreground">
-                안정화 개념 {typeof levelStats.stable_concept_count === "number"
+                익숙한 개념 {typeof levelStats.stable_concept_count === "number"
                   ? levelStats.stable_concept_count.toLocaleString()
                   : "-"}
-                , 낮은 박스 {typeof levelStats.low_box_concept_count === "number"
+                , 학습중인 개념 {typeof levelStats.low_box_concept_count === "number"
                   ? levelStats.low_box_concept_count.toLocaleString()
                   : "-"}
+                정도예요.
               </span>
             </AlertDescription>
           </Alert>

--- a/components/dashboard/start-learning-card.tsx
+++ b/components/dashboard/start-learning-card.tsx
@@ -111,25 +111,6 @@ export function StartLearningCard({
     ? "이어서 학습"
     : "학습 시작"
 
-  const recentRate =
-    typeof levelStats?.recent_correct_rate === "number"
-      ? Math.round(levelStats.recent_correct_rate * 100)
-      : null
-  const stableRatio =
-    typeof levelStats?.stable_concept_ratio === "number"
-      ? Math.round(levelStats.stable_concept_ratio * 100)
-      : null
-  const stableCount =
-    typeof levelStats?.stable_concept_count === "number"
-      ? levelStats.stable_concept_count
-      : null
-  const lowBox =
-    typeof levelStats?.low_box_concept_count === "number"
-      ? levelStats.low_box_concept_count
-      : null
-  const totalAttempts =
-    typeof levelStats?.total_attempts === "number" ? levelStats.total_attempts : null
-
   useEffect(() => {
     let mounted = true
     ;(async () => {
@@ -258,17 +239,8 @@ export function StartLearningCard({
         {levelStats ? (
           <Alert>
             <AlertDescription>
-              최근 학습 지표를 확인했어요. 현재 레벨 {typeof currentLevel === "number" ? `L${currentLevel}` : "-"} 기준
-              다음 수치를 참고하세요.
-              <span className="mt-1 block text-xs text-muted-foreground space-y-0.5">
-                <span className="block">최근 정답률 {recentRate != null ? `${recentRate}%` : "-"}</span>
-                <span className="block">
-                  안정화 개념 {stableCount != null ? stableCount.toLocaleString() : "-"}
-                  {stableRatio != null ? ` (${stableRatio}% 비중)` : ""}
-                </span>
-                <span className="block">낮은 박스 개념 {lowBox != null ? lowBox.toLocaleString() : "-"}</span>
-                <span className="block">누적 시도 {totalAttempts != null ? totalAttempts.toLocaleString() : "-"}</span>
-              </span>
+              최근 학습 데이터를 반영해 오늘 학습을 준비했어요. {typeof currentLevel === "number" ? `L${currentLevel}` : "기본"}
+              난이도로 편안하게 시작해 보세요.
             </AlertDescription>
           </Alert>
         ) : (

--- a/components/learn/session-start-alert.tsx
+++ b/components/learn/session-start-alert.tsx
@@ -41,7 +41,7 @@ export function SessionStartAlert({
         <Gauge className="h-4 w-4" /> {levelLabel} 난이도로 학습 중
       </AlertTitle>
       <AlertDescription>
-        최근 정답률 {recentRate}, 안정화 개념 비중 {stableRatio}, 낮은 박스 개념 {lowBox} 기준으로 학습을 이어갑니다.
+        최근 정답률 {recentRate}, 익숙한 개념 비중 {stableRatio}, 학습중인 개념 {lowBox} 정보를 기반으로 편안한 학습을 준비했어요.
       </AlertDescription>
     </Alert>
   )


### PR DESCRIPTION
## Summary
- replace "안정화/낮은 박스" 용어를 "익숙한/학습중인" 개념으로 정비했습니다.
- 학습 시작 카드에서 상세 지표 수치를 제거하고 간단한 안내 문구만 남겼습니다.

## Testing
- pnpm lint *(실패: Next.js ESLint 초기 설정 프롬프트 발생)*

------
https://chatgpt.com/codex/tasks/task_e_68d377ca5fb0832392565409c38d8db6