### PR TITLE
feat: 로딩 안내 UI 개선

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { ProtectedRoute } from "@/components/auth/protected-route"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { LoadingState } from "@/components/loading-spinner"
 import { useDashboard } from "@/hooks/use-dashboard"
 import { LevelCard } from "@/components/dashboard/level-card"
 import { MetricCard } from "@/components/dashboard/metric-card"
@@ -133,6 +134,13 @@ export default function DashboardPage() {
       <ProtectedRoute>
         <AppLayout>
           <div className="space-y-6">
+            <LoadingState
+              size="compact"
+              align="start"
+              title="대시보드를 준비하는 중이에요"
+              message="최근 학습 기록과 추천 정보를 불러오고 있습니다."
+              className="rounded-lg border border-dashed border-primary/20 bg-muted/20 px-6"
+            />
             <div>
               <Skeleton className="h-8 w-48 mb-2" />
               <Skeleton className="h-4 w-96" />

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { LoadingState } from "@/components/loading-spinner"
 import { StartLearningCard } from "@/components/dashboard/start-learning-card"
 import { SessionStartAlert } from "@/components/learn/session-start-alert"
 import { useToast } from "@/hooks/use-toast"
@@ -280,7 +281,13 @@ export default function LearnPage() {
     <ProtectedRoute>
       <AppLayout>
         <div className="max-w-3xl mx-auto p-4 space-y-6">
-          {loading && <div>세션 불러오는 중...</div>}
+          {loading && (
+            <LoadingState
+              size="compact"
+              title="학습 세션을 준비하고 있어요"
+              message="조금만 기다려 주세요. 여러분의 학습 데이터를 가져오는 중입니다."
+            />
+          )}
 
           {!loading && (!sid || !session || (session.items?.length ?? 0) === 0) && (
             <div className="max-w-md mx-auto">

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { LoadingState } from "@/components/loading-spinner"
 
 type ResultItem = {
   item_id: string
@@ -59,7 +60,12 @@ export default function ResultPage() {
             <h1 className="text-xl font-bold">학습 결과 요약</h1>
           </div>
 
-          {loading && <div>불러오는 중…</div>}
+          {loading && (
+            <LoadingState
+              title="결과를 준비하는 중이에요"
+              message="조금만 기다리시면 이번 학습의 요약을 정리해 드릴게요."
+            />
+          )}
           {!loading && (
             <>
               <Card>
@@ -101,3 +107,6 @@ export default function ResultPage() {
     </ProtectedRoute>
   )
 }
+// ResultPage: 세션 결과 요약과 대시보드 복귀 버튼을 보여준다.
+
+// 사용법: 학습 종료 후 /result?sid=세션ID 경로에서 접근한다.

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -13,6 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { LoadingState } from "@/components/loading-spinner"
 import { LevelHistory } from "@/components/settings/level-history"
 import { useAuth } from "@/hooks/use-auth"
 import { useTranslation } from "@/lib/i18n"
@@ -185,7 +186,13 @@ export default function SettingsPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               {entitlementLoading ? (
-                <p className="text-sm text-muted-foreground">이용권 정보를 불러오는 중...</p>
+                <LoadingState
+                  size="compact"
+                  align="start"
+                  title="이용권 정보를 확인하고 있어요"
+                  message="현재 이용 중인 혜택을 불러오는 중입니다. 잠시만 기다려 주세요."
+                  className="rounded-md border border-dashed border-primary/20 bg-muted/30 px-6"
+                />
               ) : entitlement?.status === "pro" ? (
                 <div className="space-y-3">
                   <div className="text-sm">

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,3 +1,9 @@
+// 경로: components/loading-spinner.tsx
+// 역할: 전역 로딩 스피너 및 상태 메시지 컴포넌트를 제공한다.
+// 의존관계: @/lib/utils, lucide-react/Loader2
+// 포함 함수: LoadingSpinner(), LoadingState(), FullPageLoader()
+
+import type { ReactNode } from "react"
 import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -6,27 +12,88 @@ interface LoadingSpinnerProps {
   className?: string
 }
 
+interface LoadingStateProps {
+  title?: string
+  message?: string
+  hint?: string
+  size?: "default" | "compact"
+  align?: "center" | "start"
+  className?: string
+  action?: ReactNode
+}
+
+interface FullPageLoaderProps {
+  title?: string
+  message?: string
+  hint?: string
+}
+
 export function LoadingSpinner({ size = "md", className }: LoadingSpinnerProps) {
-  const sizeClasses = {
+  const sizeClasses: Record<"sm" | "md" | "lg", string> = {
     sm: "h-4 w-4",
     md: "h-6 w-6",
     lg: "h-8 w-8",
   }
 
-  return (
-    <div className={cn("flex items-center justify-center", className)}>
-      <Loader2 className={cn("animate-spin text-muted-foreground", sizeClasses[size])} />
-    </div>
-  )
+  return <Loader2 className={cn("animate-spin text-primary", sizeClasses[size], className)} aria-hidden="true" />
 }
+// LoadingSpinner: 기본 회전 애니메이션이 적용된 아이콘을 렌더링한다.
+// 사용법: 버튼 내부나 로딩 상태를 나타낼 작은 영역에 배치한다.
 
-export function FullPageLoader() {
+export function LoadingState({
+  title = "잠시만요!",
+  message = "여러분의 정보를 가져오는 중이에요.",
+  hint,
+  size = "default",
+  align = "center",
+  className,
+  action,
+}: LoadingStateProps) {
+  const containerPadding = size === "compact" ? "py-6" : "py-12"
+  const minHeight = size === "compact" ? "min-h-[140px]" : "min-h-[220px]"
+  const alignment = align === "center" ? "items-center text-center" : "items-start text-left"
+  const spinnerPlacement = align === "center" ? "self-center" : "self-start"
+
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center space-y-4">
+    <div
+      className={cn(
+        "flex w-full flex-col justify-center gap-4",
+        containerPadding,
+        minHeight,
+        alignment,
+        className
+      )}
+    >
+      <div className={cn("relative flex h-16 w-16 items-center justify-center", spinnerPlacement)}>
+        <div className="absolute h-16 w-16 rounded-full bg-primary/10 blur-sm" aria-hidden="true" />
+        <div className="absolute h-16 w-16 rounded-full border border-primary/30 animate-ping" aria-hidden="true" />
         <LoadingSpinner size="lg" />
-        <p className="text-muted-foreground">로딩 중...</p>
       </div>
+
+      <div className="space-y-1">
+        <p className="text-lg font-semibold">{title}</p>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+
+      {hint ? <p className="text-xs text-muted-foreground/80">{hint}</p> : null}
+      {action}
     </div>
   )
 }
+// LoadingState: 스피너와 안내 문구를 함께 출력해 사용자를 안심시킨다.
+// 사용법: 페이지 또는 카드 영역에서 데이터 로딩 중일 때 보여준다.
+
+export function FullPageLoader({
+  title = "잠시만요!",
+  message = "여러분의 정보를 가져오는 중이에요.",
+  hint = "필요한 학습 데이터를 정리하고 있어요.",
+}: FullPageLoaderProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-6">
+      <LoadingState title={title} message={message} hint={hint} className="max-w-md" />
+    </div>
+  )
+}
+// FullPageLoader: 전역 Suspense fallback 등 전체 화면 로딩 상태를 표시한다.
+// 사용법: 레이아웃이나 페이지 전환 시 최상위 로딩 UI로 활용한다.
+


### PR DESCRIPTION
## Summary
- 공유 로딩 컴포넌트를 추가해 메시지와 애니메이션을 일관되게 제공
- 대시보드, 학습, 결과, 설정 화면의 로딩 구간에 새 컴포넌트를 적용
- 전역 로딩 fallback도 개선된 메시지와 비주얼을 사용하도록 업데이트

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d380fecfb0832380b17e70c6dfa77c