### PR TITLE
feat: 카드별 로딩 UX 개선

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
-﻿// 경로: app/dashboard/page.tsx
+// 경로: app/dashboard/page.tsx
 // 역할: 대시보드 메인 화면(레벨 카드, 통계, 캘린더, 추천 개념)
 // 의존관계: hooks/use-dashboard.ts, components/dashboard/*
-// 포함 함수: DashboardPage()
+// 포함 함수: LevelCardSkeleton(), MetricCardSkeleton(), StartLearningCardSkeleton(), PriorityConceptSkeletonList(), DashboardPage()
 
 "use client"
 
@@ -43,11 +43,87 @@ function normalizeAccessForCard(
     free_sessions_limit: Number.MAX_SAFE_INTEGER,
   } as AccessSummary
 }
+// normalizeAccessForCard: 관리자 계정이면 무제한 권한으로 보정한다.
+
+function LevelCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2 space-y-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-3 w-48" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Skeleton className="h-10 w-16" />
+        <Skeleton className="h-4 w-40" />
+        <div className="space-y-2 rounded-md border border-dashed border-muted p-3">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <div key={idx} className="flex items-center justify-between">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+// LevelCardSkeleton: 현재 레벨 카드의 로딩 상태를 표현한다.
+
+function MetricCardSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="pb-2 space-y-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-3 w-40" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-10 w-20" />
+      </CardContent>
+    </Card>
+  )
+}
+// MetricCardSkeleton: 대시보드 지표 카드의 로딩 상태를 보여준다.
+
+function StartLearningCardSkeleton() {
+  return (
+    <Card className="border-primary/20 bg-primary/5">
+      <CardHeader className="pb-3 space-y-2">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-3 w-48" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-6 w-20" />
+          <Skeleton className="h-6 w-32" />
+        </div>
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-4 w-56" />
+      </CardContent>
+    </Card>
+  )
+}
+// StartLearningCardSkeleton: 학습 시작 카드의 로딩 모습을 구성한다.
+
+function PriorityConceptSkeletonList() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 5 }).map((_, idx) => (
+        <div key={idx} className="flex items-start gap-3">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+// PriorityConceptSkeletonList: 추천 개념 목록의 로딩 상태를 채운다.
 
 export default function DashboardPage() {
   const { loading, error, data } = useDashboard()
 
-  // ✅ learn 페이지처럼 entitlements를 1회 더 조회해 관리자 신호를 확보
   const [entitlement, setEntitlement] = useState<AccessSummary | null>(null)
   useEffect(() => {
     let live = true
@@ -59,15 +135,16 @@ export default function DashboardPage() {
         if (live) setEntitlement(json)
       } catch {}
     })()
-    return () => { live = false }
+    return () => {
+      live = false
+    }
   }, [])
 
-  // ✅ 카드에 줄 최종 access: entitlements가 관리자면 그걸 우선, 아니면 대시보드 access 보정본
-  const accessForCard: AccessSummary | null =
+  const accessForCard =
     entitlement?.reason === "OK_ADMIN"
       ? normalizeAccessForCard(entitlement)
-      : normalizeAccessForCard(data?.access) // 기존 로직 유지 (파일 원본 구조는 동일)  :contentReference[oaicite:3]{index=3}
-
+      : normalizeAccessForCard(data?.access)
+  // accessForCard: 관리자 보정을 거친 학습 카드 접근 권한이다.
 
   const [ym, setYm] = useState<{ year: number; month: number } | null>(null)
   const [learnedDates, setLearnedDates] = useState<string[]>([])
@@ -85,11 +162,13 @@ export default function DashboardPage() {
     base.setMonth(base.getMonth() + delta)
     return { year: base.getFullYear(), month: base.getMonth() + 1 }
   }
+  // shiftMonth: 월 이동을 계산해 새 연월을 반환한다.
 
   const isDefaultMonth = useMemo(() => {
     if (!data || !ym) return false
     return data.calendar.year === ym.year && data.calendar.month === ym.month
   }, [data, ym])
+  // isDefaultMonth: 현재 선택된 달이 기본 응답과 동일한지 판단한다.
 
   const fetchMonth = async (year: number, month: number) => {
     if (!data) return
@@ -109,18 +188,21 @@ export default function DashboardPage() {
       setCalLoading(false)
     }
   }
+  // fetchMonth: 다른 월의 학습 일자를 서버에서 불러온다.
 
   const goPrev = () => {
     if (!ym) return
     const nextYm = shiftMonth(ym.year, ym.month, -1)
     setYm(nextYm)
   }
+  // goPrev: 이전 달로 이동한다.
 
   const goNext = () => {
     if (!ym) return
     const nextYm = shiftMonth(ym.year, ym.month, 1)
     setYm(nextYm)
   }
+  // goNext: 다음 달로 이동한다.
 
   useEffect(() => {
     if (!ym || !data) return
@@ -128,53 +210,7 @@ export default function DashboardPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ym?.year, ym?.month, data])
 
-  if (loading) {
-    return (
-      <ProtectedRoute>
-        <AppLayout>
-          <div className="space-y-6">
-            <div>
-              <Skeleton className="h-8 w-48 mb-2" />
-              <Skeleton className="h-4 w-96" />
-            </div>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-              {Array.from({ length: 4 }).map((_, idx) => (
-                <Card key={idx}>
-                  <CardHeader className="pb-2">
-                    <Skeleton className="h-4 w-24" />
-                  </CardHeader>
-                  <CardContent>
-                    <Skeleton className="h-8 w-16 mb-1" />
-                    <Skeleton className="h-3 w-20" />
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-            <div className="grid gap-6 md:grid-cols-2">
-              <Card className="h-[220px]">
-                <CardHeader>
-                  <Skeleton className="h-5 w-40" />
-                </CardHeader>
-                <CardContent>
-                  <Skeleton className="h-[120px] w-full" />
-                </CardContent>
-              </Card>
-              <Card className="h-[220px]">
-                <CardHeader>
-                  <Skeleton className="h-5 w-40" />
-                </CardHeader>
-                <CardContent>
-                  <Skeleton className="h-[120px] w-full" />
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </AppLayout>
-      </ProtectedRoute>
-    )
-  }
-
-  if (error || !data || !ym) {
+  if (!loading && (error || !data || !ym)) {
     return (
       <ProtectedRoute>
         <AppLayout>
@@ -187,11 +223,18 @@ export default function DashboardPage() {
     )
   }
 
-  const { level, delta30d, totalSentenceCount, studiedWordCount, priorityConcepts, gates, levelMeta, progress } = data
+  const ready = !loading && Boolean(data) && Boolean(ym)
+  const level = data?.level ?? 0
+  const delta30d = data?.delta30d ?? 0
+  const totalSentenceCount = data?.totalSentenceCount ?? 0
+  const studiedWordCount = data?.studiedWordCount ?? 0
+  const gates = data?.gates ?? { weakSessionEnabled: false }
+  const levelMeta = data?.levelMeta ?? null
+  const progress = data?.progress ?? null
   const statsForCard = progress?.stats ?? levelMeta?.stats ?? null
-  const monthLabel = `${ym.year}년 ${String(ym.month).padStart(2, "0")}월`
+  const monthLabel = ym ? `${ym.year}년 ${String(ym.month).padStart(2, "0")}월` : ""
 
-  const rankList: RankItem[] = priorityConcepts.map((item, idx) => ({
+  const rankList: RankItem[] = (data?.priorityConcepts ?? []).map((item, idx) => ({
     key: item.key || `concept_${idx + 1}`,
     name: item.name || `개념 ${idx + 1}`,
     reason: item.reason,
@@ -209,24 +252,51 @@ export default function DashboardPage() {
           </div>
 
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            <LevelCard
-              level={level}
-              delta30d={delta30d}
-              eligible={Boolean(levelMeta?.eligibleForNext)}
-              reason={levelMeta?.reason ?? "승급 평가 정보를 불러왔습니다."}
-              targetLevel={levelMeta?.targetLevel ?? level + 1}
-              stats={levelMeta?.stats ?? null}
-              policy={levelMeta?.policy ?? null}
-            />
-            <MetricCard title="작성한 문장 수" value={totalSentenceCount} tooltip="세션에서 학습자가 직접 작성하거나 복습한 문장 수" />
-            <MetricCard title="학습한 어휘 수" value={studiedWordCount} tooltip="문장 외에 학습한 단어 또는 구절 개수" />
-            <StartLearningCard
-              disabledWeakSession={!gates.weakSessionEnabled}
-              levelStats={statsForCard}
-              currentLevel={progress?.currentLevel ?? level}
-              accessSummary={accessForCard}  // ✅ 보정된 access 전달 (관리자 신호 포함)
-              totalSentenceCount={totalSentenceCount}
-            />
+            {ready ? (
+              <LevelCard
+                level={level}
+                delta30d={delta30d}
+                eligible={Boolean(levelMeta?.eligibleForNext)}
+                reason={levelMeta?.reason ?? "승급 평가 정보를 불러왔습니다."}
+                targetLevel={levelMeta?.targetLevel ?? level + 1}
+                stats={levelMeta?.stats ?? null}
+                policy={levelMeta?.policy ?? null}
+              />
+            ) : (
+              <LevelCardSkeleton />
+            )}
+
+            {ready ? (
+              <MetricCard
+                title="작성한 문장 수"
+                value={totalSentenceCount}
+                tooltip="세션에서 학습자가 직접 작성하거나 복습한 문장 수"
+              />
+            ) : (
+              <MetricCardSkeleton />
+            )}
+
+            {ready ? (
+              <MetricCard
+                title="학습한 어휘 수"
+                value={studiedWordCount}
+                tooltip="문장 외에 학습한 단어 또는 구절 개수"
+              />
+            ) : (
+              <MetricCardSkeleton />
+            )}
+
+            {ready ? (
+              <StartLearningCard
+                disabledWeakSession={!gates.weakSessionEnabled}
+                levelStats={statsForCard}
+                currentLevel={progress?.currentLevel ?? level}
+                accessSummary={accessForCard}
+                totalSentenceCount={totalSentenceCount}
+              />
+            ) : (
+              <StartLearningCardSkeleton />
+            )}
           </div>
 
           <div className="grid gap-6 md:grid-cols-2">
@@ -237,17 +307,29 @@ export default function DashboardPage() {
                   <CardDescription>학습이 진행된 날짜를 한눈에 확인하세요.</CardDescription>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Button variant="outline" size="icon" onClick={goPrev} disabled={calLoading} aria-label="이전 달">
+                  <Button variant="outline" size="icon" onClick={goPrev} disabled={calLoading || !ready} aria-label="이전 달">
                     <ChevronLeft className="h-4 w-4" />
                   </Button>
-                  <span className="text-sm tabular-nums w-[100px] text-center">{monthLabel}</span>
-                  <Button variant="outline" size="icon" onClick={goNext} disabled={calLoading} aria-label="다음 달">
+                  {ready ? (
+                    <span className="text-sm tabular-nums w-[100px] text-center">{monthLabel}</span>
+                  ) : (
+                    <Skeleton className="h-4 w-[100px]" />
+                  )}
+                  <Button variant="outline" size="icon" onClick={goNext} disabled={calLoading || !ready} aria-label="다음 달">
                     <ChevronRight className="h-4 w-4" />
                   </Button>
                 </div>
               </CardHeader>
               <CardContent>
-                {calLoading ? <Skeleton className="h-[220px] w-full" /> : <CalendarMonth year={ym.year} month={ym.month} learnedDates={learnedDates} />}
+                {ready ? (
+                  calLoading ? (
+                    <Skeleton className="h-[220px] w-full" />
+                  ) : (
+                    <CalendarMonth year={ym.year} month={ym.month} learnedDates={learnedDates} />
+                  )
+                ) : (
+                  <Skeleton className="h-[220px] w-full" />
+                )}
               </CardContent>
             </Card>
 
@@ -262,58 +344,66 @@ export default function DashboardPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <ol className="divide-y">
-                  {rankList.map((item, idx) => (
-                    <li key={item.key} className="py-3">
-                      <div className="flex items-start gap-3">
-                        <div
-                          className={[
-                            "h-8 w-8 shrink-0 grid place-items-center rounded-full text-sm font-semibold text-white",
-                            idx === 0
-                              ? "bg-amber-500"
-                              : idx === 1
-                              ? "bg-gray-500"
-                              : idx === 2
-                              ? "bg-orange-400"
-                              : "bg-muted-foreground",
-                          ].join(" ")}
-                          aria-label={`${idx + 1}위`}
-                          title={`${idx + 1}위`}
-                        >
-                          {idx + 1}
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center justify-between gap-3">
-                            <p className="font-medium truncate">{item.name}</p>
-                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                              {typeof item.score === "number" && (
-                                <span className="inline-flex items-center gap-1">
-                                  <Target className="h-3 w-3" />
-                                  {Math.round(item.score)}
-                                </span>
-                              )}
-                              {item.trend && (
-                                <span className="inline-flex items-center gap-1">
-                                  <TrendingUp
-                                    className={`h-3 w-3 ${
-                                      item.trend === "up"
-                                        ? "text-green-600"
-                                        : item.trend === "down"
-                                        ? "rotate-180 text-red-600"
-                                        : "text-muted-foreground"
-                                    }`}
-                                  />
-                                  {item.trend === "up" ? "상승" : item.trend === "down" ? "하락" : "유지"}
-                                </span>
-                              )}
+                {ready ? (
+                  rankList.length > 0 ? (
+                    <ol className="divide-y">
+                      {rankList.map((item, idx) => (
+                        <li key={item.key} className="py-3">
+                          <div className="flex items-start gap-3">
+                            <div
+                              className={[
+                                "h-8 w-8 shrink-0 grid place-items-center rounded-full text-sm font-semibold text-white",
+                                idx === 0
+                                  ? "bg-amber-500"
+                                  : idx === 1
+                                  ? "bg-gray-500"
+                                  : idx === 2
+                                  ? "bg-orange-400"
+                                  : "bg-muted-foreground",
+                              ].join(" ")}
+                              aria-label={`${idx + 1}위`}
+                              title={`${idx + 1}위`}
+                            >
+                              {idx + 1}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center justify-between gap-3">
+                                <p className="font-medium truncate">{item.name}</p>
+                                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                                  {typeof item.score === "number" && (
+                                    <span className="inline-flex items-center gap-1">
+                                      <Target className="h-3 w-3" />
+                                      {Math.round(item.score)}
+                                    </span>
+                                  )}
+                                  {item.trend && (
+                                    <span className="inline-flex items-center gap-1">
+                                      <TrendingUp
+                                        className={`h-3 w-3 ${
+                                          item.trend === "up"
+                                            ? "text-green-600"
+                                            : item.trend === "down"
+                                            ? "rotate-180 text-red-600"
+                                            : "text-muted-foreground"
+                                        }`}
+                                      />
+                                      {item.trend === "up" ? "상승" : item.trend === "down" ? "하락" : "유지"}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                              {item.reason && <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{item.reason}</p>}
                             </div>
                           </div>
-                          {item.reason && <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{item.reason}</p>}
-                        </div>
-                      </div>
-                    </li>
-                  ))}
-                </ol>
+                        </li>
+                      ))}
+                    </ol>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">추천할 개념이 아직 없어요. 학습을 이어가 주세요!</p>
+                  )
+                ) : (
+                  <PriorityConceptSkeletonList />
+                )}
               </CardContent>
             </Card>
           </div>
@@ -322,3 +412,4 @@ export default function DashboardPage() {
     </ProtectedRoute>
   )
 }
+// DashboardPage: 대시보드 전반을 구성하고 카드별 로딩을 제어한다.

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -5,9 +5,8 @@
 
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
-import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Skeleton } from "@/components/ui/skeleton"
+import { LoadingState } from "@/components/loading-spinner"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
 import { SessionList } from "@/components/history/session-list"
@@ -48,6 +47,7 @@ export default function HistoryPage() {
   const handleOpenReplay = (sessionId: string) => {
     router.push(`/history/${sessionId}`)
   }
+  // handleOpenReplay: 선택한 세션 상세 페이지로 이동한다.
 
   const handleRetry = async () => {
     setError(false)
@@ -63,39 +63,19 @@ export default function HistoryPage() {
       setLoading(false)
     }
   }
+  // handleRetry: 데이터 로딩에 실패했을 때 다시 요청을 시도한다.
 
   if (loading) {
     return (
       <ProtectedRoute>
         <AppLayout>
-          <div className="space-y-6">
-            <div>
-              <Skeleton className="h-8 w-48 mb-2" />
-              <Skeleton className="h-4 w-96" />
-            </div>
-
-            <div className="space-y-3">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <Card key={i}>
-                  <CardContent className="p-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1 space-y-2">
-                        <div className="flex items-center gap-2">
-                          <Skeleton className="h-5 w-16" />
-                          <Skeleton className="h-4 w-24" />
-                        </div>
-                        <div className="flex items-center gap-4">
-                          <Skeleton className="h-4 w-12" />
-                          <Skeleton className="h-4 w-16" />
-                          <Skeleton className="h-4 w-12" />
-                        </div>
-                      </div>
-                      <Skeleton className="h-8 w-20" />
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
+          <div className="flex min-h-[400px] items-center justify-center px-6">
+            <LoadingState
+              title="학습 이력을 불러오는 중이에요"
+              message="최근 학습 기록을 정리하고 있어요."
+              hint="잠시만 기다려 주세요."
+              className="max-w-md"
+            />
           </div>
         </AppLayout>
       </ProtectedRoute>

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,7 +1,7 @@
 ﻿// 경로: app/learn/page.tsx
 // 역할: 학습 세션 진행 페이지(문항 풀이 및 완료 처리)
 // 의존관계: app/api/sessions/*, app/api/attempts, components/dashboard/start-learning-card.tsx
-// 포함 함수: LearnPage()
+// 포함 함수: StartLearningPlaceholderSkeleton(), LearnSessionCardSkeleton(), LearnPage()
 
 "use client"
 
@@ -10,8 +10,10 @@ import { useSearchParams, useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { LoadingState } from "@/components/loading-spinner"
 import { StartLearningCard } from "@/components/dashboard/start-learning-card"
 import { SessionStartAlert } from "@/components/learn/session-start-alert"
 import { useToast } from "@/hooks/use-toast"
@@ -50,6 +52,57 @@ type CompleteResponse = {
   ok?: boolean
   level?: { leveled_up?: boolean; new_level?: number; reason?: string }
 }
+
+function StartLearningPlaceholderSkeleton() {
+  return (
+    <Card className="border-primary/20 bg-primary/5">
+      <CardHeader className="space-y-2 pb-3">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-3 w-48" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-6 w-20" />
+          <Skeleton className="h-6 w-32" />
+        </div>
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-4 w-56" />
+      </CardContent>
+    </Card>
+  )
+}
+// StartLearningPlaceholderSkeleton: 학습 시작 카드의 로딩 상태를 표현한다.
+
+function LearnSessionCardSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-5 w-20" />
+      </div>
+      <Card>
+        <CardHeader className="space-y-2">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-56" />
+          <Skeleton className="h-3 w-36" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <div className="flex justify-end gap-2">
+            <Skeleton className="h-9 w-24" />
+            <Skeleton className="h-9 w-28" />
+          </div>
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+// LearnSessionCardSkeleton: 세션 문제 카드 로딩 시 뼈대를 보여준다.
 
 export default function LearnPage() {
   const sp = useSearchParams()
@@ -93,14 +146,35 @@ export default function LearnPage() {
   useEffect(() => {
     const load = async () => {
       if (!sid) {
+        setLoading(false)
         setSession(null)
         setLevelStats(null)
         setCurrentLevel(null)
-        setLoading(false)
+        setIdx(0)
+        setAnswer("")
+        setFeedback(null)
+        setAnsweredMap({})
+        setQuestionStartAt(null)
+        setFinalReady(false)
+        setCompletedSent(false)
+        setLevelToastSent(false)
         return
       }
+      setLoading(true)
+      setSession(null)
+      setLevelStats(null)
+      setCurrentLevel(null)
+      setIdx(0)
+      setAnswer("")
+      setFeedback(null)
+      setAnsweredMap({})
+      setQuestionStartAt(null)
+      setFinalReady(false)
+      setCompletedSent(false)
+      setLevelToastSent(false)
       try {
         const res = await fetch(`/api/sessions/${encodeURIComponent(sid)}`, { cache: "no-store" })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
         const json = await res.json()
         const s: LoadedSession | null = json?.session ?? null
         setSession(s)
@@ -114,6 +188,8 @@ export default function LearnPage() {
         setAnsweredMap({})
         setQuestionStartAt(Date.now())
         setLevelToastSent(false)
+      } catch (error) {
+        console.warn("[learn] failed to load session", error)
       } finally {
         setLoading(false)
       }
@@ -276,13 +352,32 @@ export default function LearnPage() {
     return `${idx + 1} / ${session.items.length}`
   }, [session, idx])
 
+  const showLoading = loading
+  const showStartCard = !loading && (!sid || !session || (session.items?.length ?? 0) === 0)
+  const showSession = !loading && Boolean(session && current)
+
   return (
     <ProtectedRoute>
       <AppLayout>
-        <div className="max-w-3xl mx-auto p-4 space-y-6">
-          {loading && <div>세션 불러오는 중...</div>}
+        <div className="max-w-3xl mx-auto space-y-6 p-4">
+          {showLoading && (
+            <div className="space-y-4">
+              <LoadingState
+                size="compact"
+                title="학습 세션을 준비하고 있어요"
+                message="조금만 기다려 주세요. 여러분의 학습 데이터를 가져오는 중입니다."
+              />
+              {sid ? (
+                <LearnSessionCardSkeleton />
+              ) : (
+                <div className="max-w-md mx-auto">
+                  <StartLearningPlaceholderSkeleton />
+                </div>
+              )}
+            </div>
+          )}
 
-          {!loading && (!sid || !session || (session.items?.length ?? 0) === 0) && (
+          {showStartCard && (
             <div className="max-w-md mx-auto">
               <StartLearningCard
                 preferResumeLabel
@@ -294,7 +389,7 @@ export default function LearnPage() {
             </div>
           )}
 
-          {session && current && (
+          {showSession && (
             <>
               <SessionStartAlert currentLevel={currentLevel} stats={levelStats} />
               <div className="flex items-center justify-between">
@@ -333,7 +428,7 @@ export default function LearnPage() {
 
                   {answeredMap[current.item_id] === true && (
                     <div className="flex items-start justify-between gap-4">
-                      <div className="text-sm flex-1">
+                      <div className="flex-1 text-sm">
                         {feedback && (
                           <>
                             {feedback.label === "correct"
@@ -343,7 +438,7 @@ export default function LearnPage() {
                               : feedback.label === "near_miss"
                               ? "근접 정답"
                               : "오답"}
-                            <div className="text-muted-foreground mt-1">{feedback.text}</div>
+                            <div className="mt-1 text-muted-foreground">{feedback.text}</div>
                             {showAnswerLine ? (
                               <div className="mt-1 text-muted-foreground">
                                 정답: <b className="text-foreground">{current.snapshot?.answer_en}</b>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { LoadingState } from "@/components/loading-spinner"
 
 type ResultItem = {
   item_id: string
@@ -59,7 +60,12 @@ export default function ResultPage() {
             <h1 className="text-xl font-bold">학습 결과 요약</h1>
           </div>
 
-          {loading && <div>불러오는 중…</div>}
+          {loading && (
+            <LoadingState
+              title="결과를 준비하는 중이에요"
+              message="조금만 기다리시면 이번 학습의 요약을 정리해 드릴게요."
+            />
+          )}
           {!loading && (
             <>
               <Card>
@@ -101,3 +107,6 @@ export default function ResultPage() {
     </ProtectedRoute>
   )
 }
+// ResultPage: 세션 결과 요약과 대시보드 복귀 버튼을 보여준다.
+
+// 사용법: 학습 종료 후 /result?sid=세션ID 경로에서 접근한다.

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -13,6 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { AppLayout } from "@/components/layout/app-layout"
 import { ProtectedRoute } from "@/components/auth/protected-route"
+import { LoadingState } from "@/components/loading-spinner"
 import { LevelHistory } from "@/components/settings/level-history"
 import { useAuth } from "@/hooks/use-auth"
 import { useTranslation } from "@/lib/i18n"
@@ -185,7 +186,13 @@ export default function SettingsPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               {entitlementLoading ? (
-                <p className="text-sm text-muted-foreground">이용권 정보를 불러오는 중...</p>
+                <LoadingState
+                  size="compact"
+                  align="start"
+                  title="이용권 정보를 확인하고 있어요"
+                  message="현재 이용 중인 혜택을 불러오는 중입니다. 잠시만 기다려 주세요."
+                  className="rounded-md border border-dashed border-primary/20 bg-muted/30 px-6"
+                />
               ) : entitlement?.status === "pro" ? (
                 <div className="space-y-3">
                   <div className="text-sm">

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,3 +1,9 @@
+// 경로: components/loading-spinner.tsx
+// 역할: 전역 로딩 스피너 및 상태 메시지 컴포넌트를 제공한다.
+// 의존관계: @/lib/utils, lucide-react/Loader2
+// 포함 함수: LoadingSpinner(), LoadingState(), FullPageLoader()
+
+import type { ReactNode } from "react"
 import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -6,27 +12,88 @@ interface LoadingSpinnerProps {
   className?: string
 }
 
+interface LoadingStateProps {
+  title?: string
+  message?: string
+  hint?: string
+  size?: "default" | "compact"
+  align?: "center" | "start"
+  className?: string
+  action?: ReactNode
+}
+
+interface FullPageLoaderProps {
+  title?: string
+  message?: string
+  hint?: string
+}
+
 export function LoadingSpinner({ size = "md", className }: LoadingSpinnerProps) {
-  const sizeClasses = {
+  const sizeClasses: Record<"sm" | "md" | "lg", string> = {
     sm: "h-4 w-4",
     md: "h-6 w-6",
     lg: "h-8 w-8",
   }
 
-  return (
-    <div className={cn("flex items-center justify-center", className)}>
-      <Loader2 className={cn("animate-spin text-muted-foreground", sizeClasses[size])} />
-    </div>
-  )
+  return <Loader2 className={cn("animate-spin text-primary", sizeClasses[size], className)} aria-hidden="true" />
 }
+// LoadingSpinner: 기본 회전 애니메이션이 적용된 아이콘을 렌더링한다.
+// 사용법: 버튼 내부나 로딩 상태를 나타낼 작은 영역에 배치한다.
 
-export function FullPageLoader() {
+export function LoadingState({
+  title = "잠시만요!",
+  message = "여러분의 정보를 가져오는 중이에요.",
+  hint,
+  size = "default",
+  align = "center",
+  className,
+  action,
+}: LoadingStateProps) {
+  const containerPadding = size === "compact" ? "py-6" : "py-12"
+  const minHeight = size === "compact" ? "min-h-[140px]" : "min-h-[220px]"
+  const alignment = align === "center" ? "items-center text-center" : "items-start text-left"
+  const spinnerPlacement = align === "center" ? "self-center" : "self-start"
+
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center space-y-4">
+    <div
+      className={cn(
+        "flex w-full flex-col justify-center gap-4",
+        containerPadding,
+        minHeight,
+        alignment,
+        className
+      )}
+    >
+      <div className={cn("relative flex h-16 w-16 items-center justify-center", spinnerPlacement)}>
+        <div className="absolute h-16 w-16 rounded-full bg-primary/10 blur-sm" aria-hidden="true" />
+        <div className="absolute h-16 w-16 rounded-full border border-primary/30 animate-ping" aria-hidden="true" />
         <LoadingSpinner size="lg" />
-        <p className="text-muted-foreground">로딩 중...</p>
       </div>
+
+      <div className="space-y-1">
+        <p className="text-lg font-semibold">{title}</p>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+
+      {hint ? <p className="text-xs text-muted-foreground/80">{hint}</p> : null}
+      {action}
     </div>
   )
 }
+// LoadingState: 스피너와 안내 문구를 함께 출력해 사용자를 안심시킨다.
+// 사용법: 페이지 또는 카드 영역에서 데이터 로딩 중일 때 보여준다.
+
+export function FullPageLoader({
+  title = "잠시만요!",
+  message = "여러분의 정보를 가져오는 중이에요.",
+  hint = "필요한 학습 데이터를 정리하고 있어요.",
+}: FullPageLoaderProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-6">
+      <LoadingState title={title} message={message} hint={hint} className="max-w-md" />
+    </div>
+  )
+}
+// FullPageLoader: 전역 Suspense fallback 등 전체 화면 로딩 상태를 표시한다.
+// 사용법: 레이아웃이나 페이지 전환 시 최상위 로딩 UI로 활용한다.
+


### PR DESCRIPTION
## Summary
- 대시보드에 카드·캘린더·추천 목록 별 스켈레톤을 추가하고 추천 없음 안내를 보강했습니다.
- 학습 페이지에 세션 및 시작 카드 스켈레톤과 상태 초기화를 적용해 전환 시 잔상이 남지 않도록 조정했습니다.
- 학습 이력 페이지는 로딩 구간에 전용 스피너 안내를 노출하도록 변경했습니다.

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d380fecfb0832380b17e70c6dfa77c